### PR TITLE
Python slim upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.12-slim
 
 # Install GCC build dependency
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY requirements.txt /app
 
 RUN pip install --no-cache-dir -r requirements.txt
-# RUN python -m spacy download en_core_web_sm
+RUN python -m spacy download en_core_web_sm
 
 COPY *.py /app
 COPY entrypoint.sh /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM python:3.8-slim
+
+# Install GCC build dependency
+RUN apt-get update && \
+    apt-get install -y gcc g++
+
 WORKDIR /app
 
 COPY requirements.txt /app
+
 RUN pip install --no-cache-dir -r requirements.txt
-RUN python -m spacy download en_core_web_sm
+# RUN python -m spacy download en_core_web_sm
 
 COPY *.py /app
 COPY entrypoint.sh /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ bert-extractive-summarizer==0.10.1
 
 # 05 language_translation
 googletrans==4.0.0-rc1
-torch==2.1.2
+torch==2.3.0


### PR DESCRIPTION
Scout recommended upgrading to python:3.12-slim and this also required a newer version of pytorch. Furthermore, I encountered the following error before adding the GCC and G++ dependencies: ` gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory` and `error: command 'gcc' failed with exit status 1`